### PR TITLE
User can create order and add product to it

### DIFF
--- a/cypress/fixtures/create_order.json
+++ b/cypress/fixtures/create_order.json
@@ -2,11 +2,13 @@
   "message": "The item was added to your order",
   "order": {
     "id": 1,
-    "items": {
-      "id": 1,
-      "title": "Tenderloins",
-      "description": "Our finest beef",
-      "price": 199
-    }
+    "items": [
+      {
+        "id": 1,
+        "title": "Tenderloins",
+        "description": "Our finest beef",
+        "price": 199
+      }
+    ]
   }
 }

--- a/cypress/fixtures/create_order.json
+++ b/cypress/fixtures/create_order.json
@@ -1,0 +1,12 @@
+{
+  "message": "The item was added to your order",
+  "order": {
+    "id": 1,
+    "items": {
+      "id": 1,
+      "title": "Tenderloins",
+      "description": "Our finest beef",
+      "price": 199
+    }
+  }
+}

--- a/cypress/integration/DisplaysButtonWhenUserIsAuthenticated.feature.js
+++ b/cypress/integration/DisplaysButtonWhenUserIsAuthenticated.feature.js
@@ -9,7 +9,6 @@ describe('Add to order button', () => {
   })
   describe('is visible for authenticated users', () => {
     beforeEach(() => {
-      cy.server()
       cy.route({
         method: "POST",
         url: "http://localhost:3000/api/auth",

--- a/cypress/integration/UserCanAddFirstProductToOrder.feature.js
+++ b/cypress/integration/UserCanAddFirstProductToOrder.feature.js
@@ -1,0 +1,24 @@
+describe('User can create order and add product to it', () => {
+  describe('Successfully', () => {
+    beforeEach(() => {
+      cy.server()
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/orders",
+        response: 'fixture:create_order.json',
+        headers: {
+          uid: 'user@email.com'
+        }
+      })
+      cy.visit('/menu')
+    })
+
+    it('Displays success message when product is added to order', () => {
+      cy.get('data.cy=["add-to-order"]').should('contain', 'Tenderloins was added to your order')
+    })
+
+    it('')
+
+  })
+
+})

--- a/cypress/integration/UserCanAddFirstProductToOrder.feature.js
+++ b/cypress/integration/UserCanAddFirstProductToOrder.feature.js
@@ -3,6 +3,19 @@ describe('User can create order and add product to it', () => {
     beforeEach(() => {
       cy.server()
       cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/products",
+        response: 'fixture:all_products.json',
+      });
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth",
+        response: "fixture:register_user.json",
+        headers: {
+          uid: 'user@email.com'
+        }
+      });
+      cy.route({
         method: "POST",
         url: "http://localhost:3000/api/orders",
         response: 'fixture:create_order.json',
@@ -11,9 +24,18 @@ describe('User can create order and add product to it', () => {
         }
       })
       cy.visit('/menu')
+      cy.get('[data-cy="registration-form"]').within(() => {
+        cy.get('[data-cy="email-field"]').type('user@email.com')
+        cy.get('[data-cy="password-field"]').type('password')
+        cy.get('[data-cy="password-confirmation-field"]').type('password')
+        cy.get('[data-cy="submit"]').click()
+      })
     })
 
     it('Displays success message when product is added to order', () => {
+      cy.get('[cy-data="product-id-1"]').within(() => {
+        cy.get('[data-cy="order-button"]').click()
+      })
       cy.get('data.cy=["add-to-order"]').should('contain', 'Tenderloins was added to your order')
     })
 

--- a/cypress/integration/UserCanAddFirstProductToOrder.feature.js
+++ b/cypress/integration/UserCanAddFirstProductToOrder.feature.js
@@ -18,10 +18,7 @@ describe('User can create order and add product to it', () => {
       cy.route({
         method: "POST",
         url: "http://localhost:3000/api/orders",
-        response: 'fixture:create_order.json',
-        headers: {
-          uid: 'user@email.com'
-        }
+        response: 'fixture:create_order.json'
       })
       cy.visit('/menu')
       cy.get('[data-cy="registration-form"]').within(() => {
@@ -30,17 +27,17 @@ describe('User can create order and add product to it', () => {
         cy.get('[data-cy="password-confirmation-field"]').type('password')
         cy.get('[data-cy="submit"]').click()
       })
-    })
-
-    it('Displays success message when product is added to order', () => {
       cy.get('[cy-data="product-id-1"]').within(() => {
         cy.get('[data-cy="order-button"]').click()
       })
-      cy.get('data.cy=["add-to-order"]').should('contain', 'Tenderloins was added to your order')
     })
 
-    it('')
+    it('Displays success message when product is added to order', () => {
+      cy.get('#order-message').should('contain', 'Tenderloins was added to your order')
+    })
 
+    it('Displays correct amount of items in the order', () => {
+      cy.get('#order-length').should('contain', 'You have 1 item in your order')
+    })
   })
-
 })

--- a/src/components/MenuList.jsx
+++ b/src/components/MenuList.jsx
@@ -16,10 +16,12 @@ class MenuList extends React.Component {
     this.setState({ products: response.data.products })
   }
 
-addToOrder = async (productId) => {
-  let authHeader = localStorage.getItem("credentials")
-  let response = await axios.post('/orders',{product_id: productId},{headers: authHeader})
-}
+  // addToOrder = async (product) => {
+  //   let authHeader = localStorage.getItem("credentials")
+  //   let response = await axios.post('/orders', { product_id: product.id }, { headers: authHeader })
+
+  //   this.setState({ orderMessage: `${product.title} was added to your order` })
+  // }
 
 
   render() {
@@ -33,12 +35,13 @@ addToOrder = async (productId) => {
             <Item.Description cy-data={`product-description`} >{product.description}</Item.Description>
             <Item.Extra cy-data={`product-price`} >{product.price}kr</Item.Extra>
             {authenticated &&
-              <Button onClick={()=>{this.addToOrder(product.id)}} circular size="mini" animated="fade" data-cy="order-button">
+              <Button onClick={() => { this.props.addToOrder(product) }} circular size="mini" animated="fade" data-cy="order-button">
                 <Button.Content visible>Add to order!</Button.Content>
                 <Button.Content hidden>
                   <Icon name="plus square outline" />
                 </Button.Content>
               </Button>
+
             }
           </Item.Content>
         </Item>
@@ -47,6 +50,7 @@ addToOrder = async (productId) => {
 
     return (
       <>
+        
         {productList}
       </>
     )

--- a/src/components/MenuList.jsx
+++ b/src/components/MenuList.jsx
@@ -23,7 +23,6 @@ class MenuList extends React.Component {
   //   this.setState({ orderMessage: `${product.title} was added to your order` })
   // }
 
-
   render() {
     const { products } = this.state
     const { authenticated } = this.props

--- a/src/pages/Menu.jsx
+++ b/src/pages/Menu.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import MenuList from '../components/MenuList'
 import { Header, Grid, Item, Icon, Container } from 'semantic-ui-react'
-import Registration from '../components/Registration'
+import Registration from '../components/Registration';
+import axios from 'axios'
 
 class Menu extends React.Component {
   state = {
@@ -13,6 +14,7 @@ class Menu extends React.Component {
 
   addToOrder = async (product) => {
     let authHeader = localStorage.getItem("credentials")
+    debugger
     let response = await axios.post('/orders', { product_id: product.id }, { headers: authHeader })
 
    // this.setState({order: response.data.data.order.items})
@@ -34,9 +36,9 @@ class Menu extends React.Component {
             <Registration setAuthentication={() => this.setAuthentication()} />
           </Grid.Row>
           <Grid.Row>
-            {orderMessage && <p data-cy="add-to-order">{this.state.orderMessage}</p>}
+            {this.state.orderMessage && <p data-cy="add-to-order">{this.state.orderMessage}</p>}
             <Item.Group>
-              <MenuList addToOrder={this.addToOrder()} authenticated={this.state.authenticated} />
+              <MenuList addToOrder={()=> {this.addToOrder()}} authenticated={this.state.authenticated} />
             </Item.Group>
           </Grid.Row>
         </Grid>

--- a/src/pages/Menu.jsx
+++ b/src/pages/Menu.jsx
@@ -10,6 +10,15 @@ class Menu extends React.Component {
   setAuthentication = () => {
     this.setState({ authenticated: true })
   }
+
+  addToOrder = async (product) => {
+    let authHeader = localStorage.getItem("credentials")
+    let response = await axios.post('/orders', { product_id: product.id }, { headers: authHeader })
+
+   // this.setState({order: response.data.data.order.items})
+    this.setState({ orderMessage: `${product.title} was added to your order` })
+  }
+
   render() {
     return (
       <Container className="page-container" fluid>
@@ -25,8 +34,9 @@ class Menu extends React.Component {
             <Registration setAuthentication={() => this.setAuthentication()} />
           </Grid.Row>
           <Grid.Row>
+            {orderMessage && <p data-cy="add-to-order">{this.state.orderMessage}</p>}
             <Item.Group>
-              <MenuList authenticated={this.state.authenticated} />
+              <MenuList addToOrder={this.addToOrder()} authenticated={this.state.authenticated} />
             </Item.Group>
           </Grid.Row>
         </Grid>

--- a/src/pages/Menu.jsx
+++ b/src/pages/Menu.jsx
@@ -13,12 +13,23 @@ class Menu extends React.Component {
   }
 
   addToOrder = async (product) => {
-    let authHeader = localStorage.getItem("credentials")
-    debugger
-    let response = await axios.post('/orders', { product_id: product.id }, { headers: authHeader })
-
-   // this.setState({order: response.data.data.order.items})
-    this.setState({ orderMessage: `${product.title} was added to your order` })
+    let authHeader = JSON.parse(localStorage.getItem("credentials"))
+    try {
+      let response = await axios.post(
+        "/orders",
+        { product_id: product.id },
+        { headers: authHeader })
+      debugger
+      response.status === 200 && (
+        this.setState({
+          orderLength: response.data.order.items.length,
+          orderMessage: `${product.title} was added to your order`
+        })
+      )
+    }
+    catch (error) {
+      this.setState({ orderMessage: "Product couldn't be added to your order. Try again later" })
+    }
   }
 
   render() {
@@ -32,13 +43,18 @@ class Menu extends React.Component {
             <Header.Subheader>Menu List</Header.Subheader>
             </Header.Content>
           </Header>
-          <Grid.Row>
+          <Grid.Row textAlign="center">
             <Registration setAuthentication={() => this.setAuthentication()} />
           </Grid.Row>
+          {this.state.orderMessage && (
+            <div >
+              <p id="order-message">{this.state.orderMessage}</p>
+              <p id="order-length">You have {this.state.orderLength} {this.state.orderLength > 1 ? "items" : "item"} in your order</p>
+            </div>
+          )}
           <Grid.Row>
-            {this.state.orderMessage && <p data-cy="add-to-order">{this.state.orderMessage}</p>}
             <Item.Group>
-              <MenuList addToOrder={()=> {this.addToOrder()}} authenticated={this.state.authenticated} />
+              <MenuList addToOrder={this.addToOrder} authenticated={this.state.authenticated} />
             </Item.Group>
           </Grid.Row>
         </Grid>


### PR DESCRIPTION
**PT-Story:**  [https://www.pivotaltracker.com/story/show/176940948](url)
### User Story 
``` 
As a user
In order to start ordering food
I would like an order to be created when I add my first product
``` 
## Changes proposed in this pull request: 
* Adds functionality that user can add a product to an order by clicking the add to order button
* Configures addToOrder function that sends request to API with product.id as params
* The response message and response item array length is then stored in state
## What I have learned working on this feature: 
* Further connecting logic between API and Client
* Passing function argument data from child to parent 